### PR TITLE
query methods work with column with _translations suffix

### DIFF
--- a/lib/awesome_hstore_translate/active_record/class_methods.rb
+++ b/lib/awesome_hstore_translate/active_record/class_methods.rb
@@ -19,6 +19,14 @@ module AwesomeHstoreTranslate
         translation_options[:fallbacks] = before_state
       end
 
+      def get_column_name(attr)
+        column_name = attr.to_s
+        # detect column from original hstore_translate
+        column_name << '_translations' if !has_attribute?(column_name) && has_attribute?("#{column_name}_translations")
+
+        column_name
+      end
+
       protected
 
       def toggle_fallback

--- a/lib/awesome_hstore_translate/active_record/instance_methods.rb
+++ b/lib/awesome_hstore_translate/active_record/instance_methods.rb
@@ -21,7 +21,7 @@ module AwesomeHstoreTranslate
       end
 
       def read_raw_attribute(attr)
-        read_attribute(get_column_name(attr))
+        read_attribute(self.class.get_column_name(attr))
       end
 
       def write_translated_attribute(attr, value, locale= I18n.locale)
@@ -31,21 +31,11 @@ module AwesomeHstoreTranslate
       end
 
       def write_raw_attribute(attr, value)
-        write_attribute(get_column_name(attr), value)
+        write_attribute(self.class.get_column_name(attr), value)
       end
 
       def get_fallback_for_locale(locale)
         I18n.fallbacks[locale] if I18n.respond_to?(:fallbacks)
-      end
-
-      private
-
-      def get_column_name(attr)
-        column_name = attr.to_s
-        # detect column from original hstore_translate
-        column_name << '_translations' if !has_attribute?(column_name) && has_attribute?("#{column_name}_translations")
-
-        column_name
       end
     end
   end

--- a/lib/awesome_hstore_translate/active_record/query_methods.rb
+++ b/lib/awesome_hstore_translate/active_record/query_methods.rb
@@ -58,6 +58,8 @@ module AwesomeHstoreTranslate
       private
 
       def translated_attributes(opts)
+        return opts unless self.respond_to?(:translated_attribute_names)
+
         opts
           .select{ |key, _| self.translated_attribute_names.include?(key) }
           .map{ |key, value| [get_column_name(key), value] }
@@ -65,6 +67,8 @@ module AwesomeHstoreTranslate
       end
 
       def untranslated_attributes(opts)
+        return opts unless self.respond_to?(:translated_attribute_names)
+
         opts.reject{ |key, _| self.translated_attribute_names.include?(key) }
       end
     end

--- a/lib/awesome_hstore_translate/active_record/query_methods.rb
+++ b/lib/awesome_hstore_translate/active_record/query_methods.rb
@@ -58,7 +58,10 @@ module AwesomeHstoreTranslate
       private
 
       def translated_attributes(opts)
-        opts.select{ |key, _| self.translated_attribute_names.include?(key) }
+        opts
+          .select{ |key, _| self.translated_attribute_names.include?(key) }
+          .map{ |key, value| [get_column_name(key), value] }
+          .to_h
       end
 
       def untranslated_attributes(opts)

--- a/lib/awesome_hstore_translate/version.rb
+++ b/lib/awesome_hstore_translate/version.rb
@@ -1,3 +1,3 @@
 module AwesomeHstoreTranslate
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/test/awesome_hstore_translate_legacy_test.rb
+++ b/test/awesome_hstore_translate_legacy_test.rb
@@ -140,4 +140,27 @@ class AwesomeHstoreTranslateLegacyTest < AwesomeHstoreTranslate::Test
   def test_class_method_translates?
     assert_equal true, PageWithoutFallbacks.translates?
   end
+
+  def test_where_query_with_translated_value
+    PageWithFallbacks.create!(:title_raw => {'en' => 'English title', 'de' => 'Deutscher Titel'})
+    exp = PageWithFallbacks.create!(:title_raw => {'en' => 'Another English title', 'de' => 'Noch ein Deutscher Titel'})
+    res = PageWithFallbacks.where(title: 'Another English title').first
+    assert_equal(exp.id, res.id)
+  end
+
+  def test_where_query_with_translated_value_and_other
+    PageWithFallbacks.create!(:title_raw => {'en' => 'English title', 'de' => 'Deutscher Titel'},
+                              author: 'Awesome')
+    exp = PageWithFallbacks.create!(:title_raw => {'en' => 'English title', 'de' => 'Deutscher Titel'},
+                              author: 'Spectacular')
+    res = PageWithFallbacks.where(title: 'English title', author: 'Spectacular').first
+    assert_equal(exp.id, res.id)
+  end
+
+  def test_find_by_query_with_translated_value
+    PageWithFallbacks.create!(:title_raw => {'en' => 'English title', 'de' => 'Deutscher Titel'})
+    exp = PageWithFallbacks.create!(:title_raw => {'en' => 'Another English title', 'de' => 'Noch ein Deutscher Titel'})
+    res = PageWithFallbacks.find_by(title: 'Another English title')
+    assert_equal(exp.id, res.id)
+  end
 end


### PR DESCRIPTION
Query methods don't work with columns with `_translations` suffix so I create this patch to make it work. 

The change it pretty easy. Since there is `get_column_name`, I moved this method up to the public class scope so it could be called from query methods from a class scope.